### PR TITLE
Update inc-u2f-pw

### DIFF
--- a/inc-u2f-pw
+++ b/inc-u2f-pw
@@ -2,7 +2,7 @@
 ##    U2F-Token / Passwort  ##
 
 # erst: U2F-Token
-auth	[success=2 default=ignore] 	pam_u2f.so 
+auth	[success=2 default=ignore] 	pam_u2f.so  cue
 
 
 # Fallback -- funktioniert immer: Passwort


### PR DESCRIPTION
Die Option "cue" zeigt eine Nachricht an, dass man den Stick berühren soll.
"Please touch the device."

Es gibt auch [cue_prompt=your prompt here], aber das klappt unter Ubuntu 20.04 nicht, da die Funktion erst später eingeführt wurde.